### PR TITLE
[ZNA-8016] Resolve retain cycle in ZPReactNativeBaseProvider

### DIFF
--- a/ZappPlugins/ReactNative/BaseInstance/ZPReactNativeBaseProvider.swift
+++ b/ZappPlugins/ReactNative/BaseInstance/ZPReactNativeBaseProvider.swift
@@ -10,7 +10,7 @@ import UIKit
 import ZappCore
 
 open class ZPReactNativeBaseProvider : UIViewController, ZPReactNativeProviderProtocol, ZPPluginPresenterProtocol, ZPPluggableScreenProtocol {
-    public var screenPluginDelegate: ZPPlugableScreenDelegate?
+    public weak var screenPluginDelegate: ZPPlugableScreenDelegate?
     
     public private(set) var screenModel:ZLScreenModel?
     


### PR DESCRIPTION
ZPReactNativeBaseProvider has a delegate that has a strong reference
which is being set to itself, which causes React Native screens memory
to never be freed after it has been initialized.

Make the delegate reference weak to resolve the cycle.